### PR TITLE
Ruby 1.9 encoding issue

### DIFF
--- a/ext/lingua/stemmer.c
+++ b/ext/lingua/stemmer.c
@@ -9,7 +9,7 @@
 #define ENCODED_STR_NEW2(str, encoding) \
   ({ \
    VALUE _string = rb_str_new2((const char *)str); \
-   int _enc = rb_enc_find_index(encoding); \
+   int _enc = rb_enc_get_index(encoding); \
    rb_enc_associate_index(_string, _enc); \
    _string; \
    })
@@ -85,7 +85,8 @@ rb_stemmer_stem(VALUE self, VALUE word) {
       RSTRING_LEN(s_word)
   );
 
-  return ENCODED_STR_NEW2((char *)stemmed, "UTF-8");
+  VALUE rb_enc = rb_iv_get(self, "@encoding");
+  return ENCODED_STR_NEW2((char *)stemmed, rb_enc);
 }
 
 static void
@@ -107,7 +108,7 @@ void Init_stemmer_native() {
   rb_mLingua = rb_define_module("Lingua");
   rb_cStemmer = rb_define_class_under(rb_mLingua, "Stemmer", rb_cObject);
   rb_define_alloc_func(rb_cStemmer, sb_stemmer_alloc);
-  rb_eStemmerError = rb_define_class_under(rb_mLingua, "StemmerError", rb_eException);  
+  rb_eStemmerError = rb_define_class_under(rb_mLingua, "StemmerError", rb_eException);
   rb_define_private_method(rb_cStemmer, "native_init", rb_stemmer_init, 2);
   rb_define_method(rb_cStemmer, "stem", rb_stemmer_stem, 1);
 }

--- a/lib/lingua/stemmer.rb
+++ b/lib/lingua/stemmer.rb
@@ -37,10 +37,24 @@ module Lingua
     #   require 'lingua/stemmer'
     #   s = Lingua::Stemmer.new :language => 'fr'
     #
-    def initialize options = {}
+    def initialize(options={})
       @language = (options[:language] || 'en').to_s
       @encoding = (options[:encoding] || 'UTF_8').to_s
-      native_init @language, @encoding
+
+      if RUBY_VERSION >= "1.9"
+        if not @encoding.is_a?(Encoding)
+          @encoding = Encoding.find(@encoding.gsub("_", "-"))
+        end
+      else
+        @encoding = @encoding.upcase.gsub("-", "_")
+      end
+
+      native_init(@language, native_encoding(@encoding))
+    end
+
+  private
+    def native_encoding(enc)
+      RUBY_VERSION >= "1.9" ? enc.name.gsub('-', '_') : enc
     end
   end
 end

--- a/test/lingua/test_stemmer.rb
+++ b/test/lingua/test_stemmer.rb
@@ -36,7 +36,12 @@ class TestStemmer < Test::Unit::TestCase
       assert_equal word, "install"
     end
     assert_kind_of ::Lingua::Stemmer, stemmer
-    assert_equal stemmer.encoding, "UTF_8"
+
+    if RUBY_VERSION >= '1.9'
+      assert_equal stemmer.encoding, Encoding::UTF_8
+    else
+      assert_equal stemmer.encoding, "UTF_8"
+    end
   end
 
   def test_array_stemmer
@@ -53,6 +58,29 @@ class TestStemmer < Test::Unit::TestCase
     end
   end
 
+  def test_default_encoding_option
+    if RUBY_VERSION >= '1.9'
+      assert_equal ::Lingua::Stemmer.new.encoding, Encoding::UTF_8
+    else
+      assert_equal ::Lingua::Stemmer.new.encoding, "UTF_8"
+    end
+  end
+
+  def test_different_encoding_options
+    if RUBY_VERSION >= '1.9'
+      assert_equal ::Lingua::Stemmer.new(:encoding => "ISO_8859_1").encoding, Encoding::ISO_8859_1
+      assert_equal ::Lingua::Stemmer.new(:encoding => "UTF-8").encoding, Encoding::UTF_8
+      assert_equal ::Lingua::Stemmer.new(:encoding => "utf-8").encoding, Encoding::UTF_8
+      assert_equal ::Lingua::Stemmer.new(:encoding => :ISO_8859_1).encoding, Encoding::ISO_8859_1
+      assert_equal ::Lingua::Stemmer.new(:encoding => Encoding::UTF_8).encoding, Encoding::UTF_8
+    else
+      assert_equal ::Lingua::Stemmer.new(:encoding => "ISO_8859_1").encoding, "ISO_8859_1"
+      assert_equal ::Lingua::Stemmer.new(:encoding => "UTF-8").encoding, "UTF_8"
+      assert_equal ::Lingua::Stemmer.new(:encoding => "utf-8").encoding, "UTF_8"
+      assert_equal ::Lingua::Stemmer.new(:encoding => :ISO_8859_1).encoding, "ISO_8859_1"
+    end
+  end
+
   if RUBY_VERSION >= '1.9'
     def test_string_encoding
       word = "așezare"
@@ -62,6 +90,10 @@ class TestStemmer < Test::Unit::TestCase
 
       s = ::Lingua::Stemmer.new(:language => "ro", :encoding => "UTF_8")
       assert_equal s.stem(word).encoding, word.encoding
+
+      stem = ::Lingua.stemmer("installation", :language => "fr", :encoding => "ISO-8859-1")
+      assert_equal stem.encoding, Encoding::ISO_8859_1
     end
   end
+
 end


### PR DESCRIPTION
This should fix issue aurelian#8. It preserves compatibility with Ruby 1.8 and libstemmer encoding strings, of course.

I also included your example as a test. It seems to work fine.

If you're curious, it's based on this post: http://tenderlovemaking.com/2009/06/26/string-encoding-in-ruby-1-9-c-extensions/
