### PR TITLE
Drop support for ruby < 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.2
   - 2.4
   - 2.6
+  - 2.7
 script: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 PATH
   remote: .
   specs:
-    ruby-stemmer (2.0.1)
+    ruby-stemmer (2.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.5.1)
-    rake (10.4.2)
-    rake-compiler (0.9.5)
+    minitest (5.14.2)
+    rake (13.0.1)
+    rake-compiler (1.1.1)
       rake
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.5)
-  rake-compiler (~> 0.9)
+  minitest (~> 5.14)
+  rake-compiler (~> 1.1)
   ruby-stemmer!
 
 BUNDLED WITH
-   1.17.2
+   2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-stemmer (2.0.2)
+    ruby-stemmer (3.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -20,4 +20,4 @@ DEPENDENCIES
   ruby-stemmer!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2015 Aurelian Oancea
+Copyright (c) 2008-2020 Aurelian Oancea
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/lingua/stemmer.rb
+++ b/lib/lingua/stemmer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_PLATFORM.match?(/(mswin|mingw)/i)
   require "lingua/#{RUBY_VERSION.sub(/\.\d+$/, '')}/stemmer_native"
 else
@@ -36,19 +38,13 @@ module Lingua
     # will be used
     #
     #   require 'lingua/stemmer'
-    #   s = Lingua::Stemmer.new :language => 'fr'
+    #   s = Lingua::Stemmer.new language: 'fr'
     #
     def initialize(options = {})
       @language = (options[:language] || 'en').to_s
       @encoding = (options[:encoding] || 'UTF_8').to_s
 
-      if RUBY_VERSION >= '1.9'
-        unless @encoding.is_a?(Encoding)
-          @encoding = Encoding.find(@encoding.tr('_', '-'))
-        end
-      else
-        @encoding = @encoding.upcase.tr('-', '_')
-      end
+      @encoding = Encoding.find(@encoding.tr('_', '-'))
 
       native_init(@language, native_encoding(@encoding))
     end
@@ -56,7 +52,7 @@ module Lingua
     private
 
     def native_encoding(enc)
-      RUBY_VERSION >= '1.9' ? enc.name.tr('-', '_') : enc
+      enc.name.tr('-', '_')
     end
   end
 end

--- a/lib/lingua/version.rb
+++ b/lib/lingua/version.rb
@@ -1,5 +1,5 @@
 module Lingua
   class Stemmer
-    VERSION = '2.0.1'
+    VERSION = '3.0.0'
   end
 end

--- a/ruby-stemmer.gemspec
+++ b/ruby-stemmer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version = Lingua::Stemmer::VERSION
 
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.require_paths = ['lib']
   s.authors = ['Aurelian Oancea', 'Yury Korolev']

--- a/ruby-stemmer.gemspec
+++ b/ruby-stemmer.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Expose libstemmer_c to Ruby.'
 
-  s.add_development_dependency 'minitest', '~> 5.5'
-  s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'minitest', '~> 5.14'
+  s.add_development_dependency 'rake-compiler', '~> 1.1'
 end

--- a/test/lingua/test_stemmer.rb
+++ b/test/lingua/test_stemmer.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 require 'helper'
 
@@ -20,8 +20,8 @@ class TestStemmer < Minitest::Test
 
   def test_latin
     ::Lingua::Stemmer.new language: 'latin', encoding: 'ISO_8859_1'
-  rescue StandardError => error
-    flunk "Expected latin to be loaded but failed with #{error}"
+  rescue StandardError => e
+    flunk "Expected latin to be loaded but failed with #{e}"
   end
 
   def test_stem
@@ -36,12 +36,7 @@ class TestStemmer < Minitest::Test
       assert_equal word, 'install'
     end
     assert_kind_of ::Lingua::Stemmer, stemmer
-
-    if RUBY_VERSION >= '1.9'
-      assert_equal stemmer.encoding, Encoding::UTF_8
-    else
-      assert_equal stemmer.encoding, 'UTF_8'
-    end
+    assert_equal stemmer.encoding, Encoding::UTF_8
   end
 
   def test_array_stemmer
@@ -73,41 +68,32 @@ class TestStemmer < Minitest::Test
   end
 
   def test_different_encoding_options
-    if RUBY_VERSION >= '1.9'
-      assert_equal ::Lingua::Stemmer.new(encoding: 'ISO_8859_1').encoding, Encoding::ISO_8859_1
-      assert_equal ::Lingua::Stemmer.new(encoding: 'UTF-8').encoding, Encoding::UTF_8
-      assert_equal ::Lingua::Stemmer.new(encoding: 'utf-8').encoding, Encoding::UTF_8
-      assert_equal ::Lingua::Stemmer.new(encoding: :ISO_8859_1).encoding, Encoding::ISO_8859_1
-      assert_equal ::Lingua::Stemmer.new(encoding: Encoding::UTF_8).encoding, Encoding::UTF_8
-    else
-      assert_equal ::Lingua::Stemmer.new(encoding: 'ISO_8859_1').encoding, 'ISO_8859_1'
-      assert_equal ::Lingua::Stemmer.new(encoding: 'UTF-8').encoding, 'UTF_8'
-      assert_equal ::Lingua::Stemmer.new(encoding: 'utf-8').encoding, 'UTF_8'
-      assert_equal ::Lingua::Stemmer.new(encoding: :ISO_8859_1).encoding, 'ISO_8859_1'
-    end
+    assert_equal ::Lingua::Stemmer.new(encoding: 'ISO_8859_1').encoding, Encoding::ISO_8859_1
+    assert_equal ::Lingua::Stemmer.new(encoding: 'UTF-8').encoding, Encoding::UTF_8
+    assert_equal ::Lingua::Stemmer.new(encoding: 'utf-8').encoding, Encoding::UTF_8
+    assert_equal ::Lingua::Stemmer.new(encoding: :ISO_8859_1).encoding, Encoding::ISO_8859_1
+    assert_equal ::Lingua::Stemmer.new(encoding: Encoding::UTF_8).encoding, Encoding::UTF_8
   end
 
-  if RUBY_VERSION >= '1.9'
-    def test_string_encoding
-      word = 'așezare'
+  def test_string_encoding
+    word = 'așezare'
 
-      stem = ::Lingua.stemmer(word, language: 'ro', encoding: 'UTF_8')
-      assert_equal word.encoding, stem.encoding
+    stem = ::Lingua.stemmer(word, language: 'ro', encoding: 'UTF_8')
+    assert_equal word.encoding, stem.encoding
 
-      s = ::Lingua::Stemmer.new(language: 'ro', encoding: 'UTF_8')
-      assert_equal s.stem(word).encoding, word.encoding
+    s = ::Lingua::Stemmer.new(language: 'ro', encoding: 'UTF_8')
+    assert_equal s.stem(word).encoding, word.encoding
 
-      stem = ::Lingua.stemmer('installation', language: 'fr', encoding: 'ISO-8859-1')
-      assert_equal stem.encoding, Encoding::ISO_8859_1
-    end
+    stem = ::Lingua.stemmer('installation', language: 'fr', encoding: 'ISO-8859-1')
+    assert_equal stem.encoding, Encoding::ISO_8859_1
+  end
 
-    def test_lithuanian_stem
-      stemmer = ::Lingua::Stemmer.new(language: 'lt')
-      %w[
-        kompiuteris kompiuterio kompiuteriui kompiuteriu kompiuteri
-      ].each do |word|
-        assert_equal stemmer.stem(word), 'kompiuter'
-      end
+  def test_lithuanian_stem
+    stemmer = ::Lingua::Stemmer.new(language: 'lt')
+    %w[
+      kompiuteris kompiuterio kompiuteriui kompiuteriu kompiuteri
+    ].each do |word|
+      assert_equal stemmer.stem(word), 'kompiuter'
     end
   end
 end


### PR DESCRIPTION
Drop support for ruby < 2.4.

Updated dev dependencies: minitest and rake-complier.